### PR TITLE
Fix compatibility with OpenSesame 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,10 @@ I dare to say that this is the best implementation of a movie player for OpenSes
 Like moviepy, this module is licensed under the MIT license:
 
 The MIT License (MIT)
-Copyright (c) 2016 Daniel Schreij
+Copyright (c) 2016-2020 Daniel Schreij
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-
-

--- a/media_player_mpy/info.yaml
+++ b/media_player_mpy/info.yaml
@@ -72,5 +72,5 @@ controls:
     var: event_handler
   -
     name: "info_label"
-    label: "<small><b>Media Player OpenSesame Plugin, Copyright (2015-2016) Daniel Schreij</b></small>"
+    label: "<small><b>Media Player OpenSesame Plugin, Copyright (2015-2020) Daniel Schreij</b></small>"
     type: text

--- a/media_player_mpy/media_player_mpy.py
+++ b/media_player_mpy/media_player_mpy.py
@@ -291,6 +291,9 @@ class media_player_mpy(item):
 
 
 class qtmedia_player_mpy(media_player_mpy, qtautoplugin):
+	
+	lazy_init = False
+	
 	def __init__(self, name, experiment, script=None):
 		# Call parent constructors.
 		media_player_mpy.__init__(self, name, experiment, script)
@@ -370,5 +373,3 @@ class qtmedia_player_mpy(media_player_mpy, qtautoplugin):
 
 
 		
-
-


### PR DESCRIPTION
OpenSesame 3.3 doesn't automatically initialize the controls of all items to improve performance. However, some items (like this one) assume that this happens, and the old behavior can be restored by setting the class property `lazy_init` to `False`.