### PR TITLE
Fix compatibility with Python 3

### DIFF
--- a/media_player_mpy/info.yaml
+++ b/media_player_mpy/info.yaml
@@ -3,7 +3,7 @@ category: "Visual stimuli"
 description: Media player based on moviepy
 url: "https://github.com/dschreij/opensesame-plugin-mediaplayer"
 icon: "os-media_player_mpy"
-version: "0.1.8"
+version: "0.1.9"
 controls:
   -
     name: "video_file"

--- a/media_player_mpy/media_player_mpy.py
+++ b/media_player_mpy/media_player_mpy.py
@@ -136,7 +136,7 @@ class media_player_mpy(item):
 			(self.windowsize[1] - self.dest_size[1]) / 2)
 
 		# Set handler of frames and user input
-		if type(self.var.canvas_backend) in [unicode,str]:
+		if isinstance(self.var.canvas_backend, basestring):
 			if self.var.canvas_backend == u"legacy" or self.var.canvas_backend \
 				== u"droid":
 				from handlers import LegacyHandler


### PR DESCRIPTION
`unicode` is undefined in Python 3. I also bumped the version to 0.1.9. Can you package this for pip and conda?